### PR TITLE
solve:  programmers lv2 메뉴리뉴얼

### DIFF
--- a/KAKAO/LV2/메뉴리뉴얼/방석진.py
+++ b/KAKAO/LV2/메뉴리뉴얼/방석진.py
@@ -1,0 +1,21 @@
+from itertools import combinations
+
+def solution(orders, course):
+    answer = list()
+
+    for menu_num in course:
+        menu_dict = dict()
+        for order in orders:
+            menu_combination = combinations(sorted(order), menu_num)
+            for menu_combination_iter in menu_combination:
+                try:
+                    menu_dict["".join(menu_combination_iter)] += 1
+                except:
+                    menu_dict["".join(menu_combination_iter)] = 1         
+
+        max_count = max(menu_dict.values())
+        for key in menu_dict.keys():
+            if menu_dict[key] == max_count and menu_dict[key] > 1:
+                answer.append(key)
+
+    return sorted(answer)


### PR DESCRIPTION
``` python
from itertools import combinations

def solution(orders, course):
    answer = list()

    for menu_num in course:
        menu_dict = dict()
        for order in orders:
            menu_combination = combinations(sorted(order), menu_num)
            for menu_combination_iter in menu_combination:
                try:
                    menu_dict["".join(menu_combination_iter)] += 1
                except:
                    menu_dict["".join(menu_combination_iter)] = 1         

        max_count = max(menu_dict.values())
        for key in menu_dict.keys():
            if menu_dict[key] == max_count and menu_dict[key] > 1:
                answer.append(key)

    return sorted(answer)
```

처음에 combination 쓰면 쉽게 풀 줄 알고 손코딩 안하고 바로 코드 작성했는데 그대로 한시간 버렸다..ㅎ
이 때는 orders에 나오는 알파벳을 모두 모아놓고, 그 알파벳 가지고 combination을 돌린다음에 그 조합이 order 안에 속하는지 확인하는 방법을 택했다. 
일단 `set` 자료형으로 바꾸고  `set`자료형에 이용가능한 `intersection()` 메소드를 이용해서 부분집합 여부를 계산했었는데... 로직은 맞았지만 tc 3개가 시간초과가 떠서 이 방법은 폐기했다. 

두번째 방법으로는 orders에 있는 주문목록에서 combination을 돌리는 방법이다. 
애초에 orders에 있는 목록이 주문한 적이 있는 조합이라서 훨씬 효율적이었다... 애초에 그 조합이 부분집합인지 확인하는 절차가 필요없으니까! 
아마 첫번쨰 풀이에서는  부분집합인지 확인하는 과정에서 시간초과가 뜬 것 같다. 

주의할점은, `combination`  모듈의 경우 조합의 대상이 무엇인지 생각해서 조합을 생성하는게 아니라, 조합 대상의 index를 기준으로 조합을 생성한다는 점이다. 
예를들어, 

```python 
x = "abc"
y = "cab"
```

가 있고, `x`와 `y`를 각각 3C2의 조합을 생성한다면,
`combination` 모듈은 '아, a와 b와 c로 2개씩 선택하는 조합을 생성해야지' 가 아니라 
'x[0]과 x[1]과 x[2]로 2개씩 선택해야지' 의 논리로 연산을 수행하게 된다.

따라서 string x와 y는 동일한 알파벳을 가지고 3C2의 조합을 가지고 돌려도 다른 결과를 뱉어낸다. 
```python 
for i in combination(x, 2):
  print(i)
# ('a', 'b'), ('a', 'c'), ('b', 'c')

for i in combination(x, 2):
  print(i)
# ('c', 'a'), ('c', 'b'), ('a', 'b')
```
그래서 조합을 돌리기 전에 정렬을 꼭해줘야 한다!




