### PR TITLE
[Baekjoon] 2304 - 창고 다각형 

### DIFF
--- a/Baekjoon/2304-창고다각형/방석진.py
+++ b/Baekjoon/2304-창고다각형/방석진.py
@@ -1,0 +1,24 @@
+N = int(input())
+
+coord_dict = dict()
+
+for _ in range(N):
+    key, value = map(int, input().split())
+    coord_dict[key] = value
+
+sorted_coord = sorted(coord_dict.items(), key = lambda x : x[1])
+
+initial_x, initial_y = sorted_coord.pop()
+left_x = initial_x; right_x = initial_x; answer = 0
+answer += initial_y
+
+for x, y in reversed(sorted_coord):
+    if right_x < x: 
+        answer += (x - right_x) * y
+        right_x = x
+    if left_x > x:
+        answer += (left_x - x) * y
+        left_x = x
+
+print(answer)
+    


### PR DESCRIPTION
``` python
N = int(input())

coord_dict = dict()

for _ in range(N):
    key, value = map(int, input().split())
    coord_dict[key] = value

sorted_coord = sorted(coord_dict.items(), key = lambda x : x[1])

initial_x, initial_y = sorted_coord.pop()
left_x = initial_x; right_x = initial_x
answer = initial_y

for x, y in reversed(sorted_coord):
    if right_x < x: 
        answer += (x - right_x) * y
        right_x = x
    if left_x > x:
        answer += (left_x - x) * y
        left_x = x

print(answer)
```
## Solution 
### 1. greedy
원래는 greedy한 방식으로 dict의 key를 정렬해서 왼쪽 좌표부터 오른쪽으로 비교해가며 풀어보려고 했다. 
이 방식은 초기 설정도 따로 해줘야하고 분기해줘야할 조건문들이 너무 많아져서 조금 생각하다가 버렸다

### 2. recursive
그 다음에 생각한 방식은 dictionary를 value로 정렬한 후에, 가장 높은 곳의 x 좌표를 기준으로 우측, 그리고 좌측으로 뻗어가는 재귀로 답을 구하려고 했다. 
우측으로 뻗어가는 재귀라면 자기보다 우측에 있는 x 좌표 중 가장 높은 곳의 x좌표를 기준으로 넓이를 더해준다. 그리고 그 곳의 x좌표를 건네줘서 재귀.
종료조건은 x보다 오른쪽에 남아있는 좌표가 없을 때 종료. 
좌측 역시 동일한 방식으로 진행한다.

나쁘지 않은 방식 같지만 생각해보니 재귀보다 for문을 이용하는게 훨씬 쉬울 것 같아서 이 방식도 폐기.

### 3. 최종 풀이 
먼저 dictionary를 value값 기준으로 정렬해서 가장 높은 곳의 x좌표를 찾아준다. 
해당 x, y 튜플은 pop해서 없애주고, 그 값으로 `left_x`, `right_x` 를 초기화해준다. 
answer도 y값으로 초기화해준다. (가장 높은 기둥의 넓이는 더 옆으로 확장되지 않으니까)
`left_x` : 현재까지 가장 왼쪽에 있는 가장 높은 기둥의 x 좌표
`right_x`: 현재까지 가장 오른쪽에 있는 가장 높은 기둥의 x좌표

이미 value대로 정렬된 list가 있으므로 이를 reverse해서 하나씩 `left_x`, `right_x`와 비교해가며 조건에 맞다면 면적을 추가해주고 값들을 업데이트 해줌.

## Takeaways
영권님 말씀대로 생각하는 재미가 있는 문제였다 !
시간은 오래걸렸지만 여러 방식으로 고민해보다가 나름 깔끔한 풀이 방식을 찾은 것 같아 뿌듯했다.